### PR TITLE
Add filter: show only latest post from each feed

### DIFF
--- a/app/lang/en.php
+++ b/app/lang/en.php
@@ -21,6 +21,7 @@ return [
     'common.all_tags' => 'All Tags',
     'common.all_topics' => 'All Topics',
     'common.simplified' => 'Simplified',
+    'common.latest_per_feed' => 'Latest per feed',
     'common.view_mode' => 'View Mode',
     'common.view_cards' => 'Cards',
     'common.view_list' => 'List',

--- a/app/lang/es.php
+++ b/app/lang/es.php
@@ -21,6 +21,7 @@ return [
     'common.all_tags' => 'Todas las Etiquetas',
     'common.all_topics' => 'Todos los Temas',
     'common.simplified' => 'Simplificado',
+    'common.latest_per_feed' => 'Último por feed',
     'common.view_mode' => 'Modo de Vista',
     'common.view_cards' => 'Tarjetas',
     'common.view_list' => 'Lista',

--- a/app/lang/pt-BR.php
+++ b/app/lang/pt-BR.php
@@ -21,6 +21,7 @@ return [
     'common.all_tags' => 'Todos Tópicos',
     'common.all_topics' => 'Todos Tópicos',
     'common.simplified' => 'Simplificado',
+    'common.latest_per_feed' => 'Último por feed',
     'common.view_mode' => 'Modo de Visualização',
     'common.view_cards' => 'Cartões',
     'common.view_list' => 'Lista',

--- a/app/setup/2026-01-28.sql
+++ b/app/setup/2026-01-28.sql
@@ -1,0 +1,13 @@
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+ALTER TABLE `feeds`
+ADD COLUMN IF NOT EXISTS `last_feed_item_id` int(10) UNSIGNED DEFAULT NULL AFTER `proxy_only`;
+
+ALTER TABLE `feeds`
+ADD INDEX IF NOT EXISTS `idx_last_feed_item_id`(`last_feed_item_id`) USING BTREE;
+
+-- Initialize the last_feed_item_id for existing feeds
+UPDATE `feeds` SET `last_feed_item_id` = (SELECT `feed_items`.`id` FROM `feed_items` WHERE `feed_items`.`feed_id` = `feeds`.`id` AND `feed_items`.`is_visible` = 1  AND `feed_items`.`guid` = `feeds`.`last_post_id` ORDER BY `feed_items`.`id` DESC LIMIT 1);
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/app/src/Commands/FeedProcessor.php
+++ b/app/src/Commands/FeedProcessor.php
@@ -402,7 +402,9 @@ class FeedProcessor
             $this->processPaginatedRssFeed($feed, $simplePie, $count, $updated, $lastGuid, $processedItems, $maxItemsToProcess);
 
             if ($updated && $lastGuid) {
+                $lastFeedItemId = DB::queryFirstField("SELECT id FROM feed_items WHERE guid = %s ORDER BY id DESC LIMIT 1", $lastGuid);
                 DB::update('feeds', [
+                    'last_feed_item_id' => $lastFeedItemId,
                     'last_post_id' => $lastGuid,
                     'last_updated' => DB::sqleval("NOW()")
                 ], 'id=%i', $feed['id']);
@@ -679,7 +681,9 @@ class FeedProcessor
             $this->processPaginatedCsvFeed($feed, $count, $updated, $lastGuid);
 
             if ($updated && $lastGuid) {
+                $lastFeedItemId = DB::queryFirstField("SELECT id FROM feed_items WHERE guid = %s ORDER BY id DESC LIMIT 1", $lastGuid);
                 DB::update('feeds', [
+                    'last_feed_item_id' => $lastFeedItemId,
                     'last_post_id' => $lastGuid,
                     'last_updated' => DB::sqleval("NOW()")
                 ], 'id=%i', $feed['id']);
@@ -929,7 +933,9 @@ class FeedProcessor
             }
 
             if ($updated && $lastGuid) {
+                $lastFeedItemId = DB::queryFirstField("SELECT id FROM feed_items WHERE guid = %s ORDER BY id DESC LIMIT 1", $lastGuid);
                 DB::update('feeds', [
+                    'last_feed_item_id' => $lastFeedItemId,
                     'last_post_id' => $lastGuid,
                     'last_updated' => DB::sqleval("NOW()")
                 ], 'id=%i', $feed['id']);
@@ -1142,7 +1148,9 @@ class FeedProcessor
             $this->processPaginatedXmlFeed($feed, $xml, $count, $updated, $lastGuid, $processedItems, $maxItemsToProcess);
 
             if ($updated && $lastGuid) {
+                $lastFeedItemId = DB::queryFirstField("SELECT id FROM feed_items WHERE guid = %s ORDER BY id DESC LIMIT 1", $lastGuid);
                 DB::update('feeds', [
+                    'last_feed_item_id' => $lastFeedItemId,
                     'last_post_id' => $lastGuid,
                     'last_updated' => DB::sqleval("NOW()")
                 ], 'id=%i', $feed['id']);

--- a/app/src/Controllers/HomeController.php
+++ b/app/src/Controllers/HomeController.php
@@ -42,6 +42,8 @@ class HomeController
         $feedId = isset($params['feed']) ? (int)$params['feed'] : null;
         $categorySlug = $params['category'] ?? null;
         $tagSlug = $params['tag'] ?? null;
+        $latestPerFeed = !empty($params['latest']);
+
 
         $query = "SELECT fi.*, f.title as feed_title, f.site_url, f.language
                  FROM feed_items fi
@@ -50,6 +52,12 @@ class HomeController
         $countQuery = "SELECT COUNT(*) FROM feed_items fi
                       JOIN feeds f ON fi.feed_id = f.id
                       WHERE fi.is_visible = 1";
+
+        if ($latestPerFeed) {
+            $query .= " AND fi.id = f.last_feed_item_id";
+            $countQuery .= " AND fi.id = f.last_feed_item_id";
+        }
+
         $queryParams = [];
 
         if (!empty($search)) {
@@ -98,7 +106,8 @@ class HomeController
             'category' => $categorySlug,
             'tag' => $tagSlug,
             'page' => $page,
-            'perPage' => $perPage
+            'perPage' => $perPage,
+            'latest' => $latestPerFeed ? 1 : 0
         ]);
 
         $countCacheKey = $this->cache->key('items', 'count', $filterHash);
@@ -143,6 +152,7 @@ class HomeController
             'selectedFeed' => $feedId,
             'selectedCategory' => $categorySlug,
             'selectedTag' => $tagSlug,
+            'latestPerFeed' => $latestPerFeed,
             'pagination' => [
                 'current' => $page,
                 'total' => $totalPages,

--- a/app/templates/home.php
+++ b/app/templates/home.php
@@ -21,9 +21,6 @@
                                     <option value="list"><?= __('common.view_list') ?></option>
                                 </select>
                             </div>
-                            <div class="me-md-2 mb-2 mb-md-0">
-                                <input type="checkbox" id="simplified-view" /> <label for="simplified-view" class="me-3"><?= __('common.simplified') ?></label>
-                            </div>
                         </div>
                         <div class="d-md-flex">
                             <div class="d-md-flex me-md-2 mb-3 mb-md-0">
@@ -63,6 +60,15 @@
                                     </button>
                                 </div>
                             </div>
+                        </div>
+                    </div>
+                    <div class="mt-2 d-md-flex justify-content-start">
+                        <div class="me-md-2 mb-2 mb-md-0">
+                            <input type="checkbox" id="simplified-view" /> <label for="simplified-view" class="me-3"><?= __('common.simplified') ?></label>
+                        </div>
+                        <div class="me-md-2 mb-2 mb-md-0">
+                            <input type="checkbox" name="latest" value="1" id="latest-per-feed" <?= !empty($latestPerFeed) ? 'checked' : '' ?> />
+                            <label for="latest-per-feed" class="me-3"><?= __('common.latest_per_feed') ?></label>
                         </div>
                     </div>
                 </form>
@@ -178,7 +184,8 @@
                                 'search' => $search,
                                 'feed' => $selectedFeed,
                                 'category' => $selectedCategory ?? null,
-                                'tag' => $selectedTag ?? null
+                                'tag' => $selectedTag ?? null,
+                                'latest' => !empty($latestPerFeed) ? '1' : null
                             ]);
                             $queryString = !empty($queryParams) ? '?' . http_build_query($queryParams) : '';
                             ?>
@@ -302,6 +309,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Filter save/load functionality
     const categorySelect = document.getElementById('category-select');
     const tagSelect = document.getElementById('tag-select');
+    const latestPerFeedCheckbox = document.getElementById('latest-per-feed');
     const saveFilterBtn = document.getElementById('save-filter-btn');
     const clearFilterBtn = document.getElementById('clear-filter-btn');
     const filterForm = categorySelect.closest('form');
@@ -314,6 +322,12 @@ document.addEventListener('DOMContentLoaded', function() {
     tagSelect.addEventListener('change', function() {
         filterForm.submit();
     });
+
+    if (latestPerFeedCheckbox) {
+        latestPerFeedCheckbox.addEventListener('change', function() {
+            filterForm.submit();
+        });
+    }
         
     // Load saved filters on page load
     function loadSavedFilters() {


### PR DESCRIPTION
Boa noite!  Primeiro, queria dar um parabéns pelo projeto. Eu tava há um tempo tentando achar um repositório de blogs brasileiros e o lerama caiu como uma luva :)

Esse PR resolve um problema que eu noto em vários agregadores: alguns blogs dominam a listagem porque os autores postam com maior frequência! Eu sigo vários feeds que postam 1x por mês, e outros que postam diariamente.

A ideia é adicionar um botão (checkbox) que, quando marcado, mostra apenas a última postagem de cada feed. A ordenação por data segue valendo (então quem posta com maior frequência naturalmente vai subir pro topo), mas eu achei que ajudou bastante na "discoverability".

Pro query da home não ficar pesado, adicionei um novo campo na tabela `feeds`, `last_feed_item_id`. Daí sempre que um feed é processado, ele é atualizado.

Como os feeds são importados em ordem inversa (do post mais novo pro mais antigo), aproveitei a variável `$lastGuid` pra garantir que o feed_id salvo é realmente do post mais recente de cada feed.

Criei também uma migration pra adicionar esse valor nos feeds já existentes.

Daí optei por passar o checkbox de "Simplificado" junto com esse novo (chamei de "Último por feed" kkk aceito sugestões) pra baixo pra não quebrar o layout.

Opção desmarcada (tudo funciona igual a versão atual, repare que blogs mais ativos dominam a listagem):

<img width="1841" height="966" alt="image" src="https://github.com/user-attachments/assets/043e0c07-25c7-4beb-a40c-87d525d93f8a" />

Opção marcada (consigo ver mais variedade na listagem!):

<img width="1582" height="963" alt="image" src="https://github.com/user-attachments/assets/40bf4122-549f-492b-9610-b6354fff4eee" />

Abraço!
